### PR TITLE
fix: broken wasm in browser

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -25,20 +25,17 @@ export default function wasm (options = {}) {
 
     banner:  `
       function _loadWasmModule (sync, src, imports) {
-        var len = src.length
-        var trailing = src[len-2] == '=' ? 2 : src[len-1] == '=' ? 1 : 0
-        var buf = new Uint8Array((len * 3/4) - trailing)
-
-        var _table = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
-        var table = new Uint8Array(130)
-        for (var c = 0; c < _table.length; c++) table[_table.charCodeAt(c)] = c
-
-        for (var i = 0, b = 0; i < len; i+=4) {
-          var second = table[src.charCodeAt(i+1)]
-          var third = table[src.charCodeAt(i+2)]
-          buf[b++] = (table[src.charCodeAt(i)] << 2) | (second >> 4)
-          buf[b++] = ((second & 15) << 4) | (third >> 2)
-          buf[b++] = ((third & 3) << 6) | (table[src.charCodeAt(i+3)] & 63)
+        var buf = null
+        var isNode = typeof process !== 'undefined' && process.versions != null && process.versions.node != null
+        if (isNode) {
+          buf = Buffer.from(src, 'base64')
+        } else {
+          var raw = window.atob(src)
+          var rawLength = raw.length
+          buf = new Uint8Array(new ArrayBuffer(rawLength))
+          for(i = 0; i < rawLength; i++) {
+             buf[i] = raw.charCodeAt(i)
+          }
         }
 
         if (imports && !sync) {


### PR DESCRIPTION
In browser plugin did not working, always fail with errors:
Wasm decoding failed: unknown section code #0xXX @+XX

I changed base64 implementation in banner to window.atob for browsers and Buffer.from for node, and now all working fine. All test passed.